### PR TITLE
Add setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ Display:
 
 Rotary Encoder:
 Adafruit I2C Stemma QT Rotary Encoder Breakout with NeoPixel
+
+## Setup
+
+Run `setup.sh` to install PlatformIO and the required libraries:
+
+```bash
+./setup.sh
+```
+
+This script installs PlatformIO using `pip` (if needed) and fetches all project dependencies defined in `platformio.ini`.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Ensure Python 3 and pip are available
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Installing Python3 and pip..."
+    sudo apt-get update
+    sudo apt-get install -y python3 python3-pip
+fi
+
+# Install PlatformIO using pip if it's not installed
+if ! command -v platformio >/dev/null 2>&1; then
+    echo "Installing PlatformIO..."
+    python3 -m pip install --user -U platformio
+    export PATH="$PATH:$HOME/.local/bin"
+fi
+
+# Install the project libraries defined in platformio.ini
+platformio pkg install
+
+echo "Setup complete. You can now build the firmware using 'platformio run'."
+


### PR DESCRIPTION
## Summary
- add `setup.sh` script to install PlatformIO and project libraries
- document how to use the setup script in the README

## Testing
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68422f1783d48323af74f6b5c67da0f6