### PR TITLE
Implement starting page roller

### DIFF
--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -121,6 +121,47 @@ bool ui_init_book_roller(void)
     return true;
 }
 
+bool ui_init_starting_page_roller(void)
+{
+    if (ui_StartingPageCount == NULL) {
+        Serial.println("ui_StartingPageCount is NULL, cannot initialize roller");
+        return false;
+    }
+
+    const Book* book = book_manager_get_book_by_name(selectedbookname);
+    if (book == nullptr) {
+        Serial.println("Selected book not found for starting page roller");
+        return false;
+    }
+
+    static char page_options[2048];
+    page_options[0] = '\0';
+
+    for (uint16_t i = 0; i <= book->totalPages; ++i) {
+        char buf[8];
+        sprintf(buf, "%u", i);
+        strcat(page_options, buf);
+        if (i < book->totalPages) {
+            strcat(page_options, "\n");
+        }
+    }
+
+    lv_roller_set_options(ui_StartingPageCount, page_options, LV_ROLLER_MODE_NORMAL);
+
+    uint16_t default_page = book->pagesRead;
+    if (default_page > book->totalPages) {
+        default_page = 0;
+    }
+    lv_roller_set_selected(ui_StartingPageCount, default_page, LV_ANIM_OFF);
+
+    Serial.print("Initialized start page roller for ");
+    Serial.print(selectedbookname);
+    Serial.print(" with total pages: ");
+    Serial.println(book->totalPages);
+
+    return true;
+}
+
 void ui_manager_init(void)
 {
     // Initialize UI from LVGL helper
@@ -153,6 +194,7 @@ void ui_handle_button_press(void)
         // Update selected book name before transitioning
         ui_update_selected_book_name();
         ui_sync_selected_book_name();
+        ui_init_starting_page_roller();
         lv_disp_load_scr(ui_SelectStartScreen);
     }
     else if (current_screen == ui_SelectStartScreen) {

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -21,4 +21,7 @@ const char* ui_get_selected_book_name(void);
 // Function to initialize the book roller with data from JSON
 bool ui_init_book_roller(void);
 
+// Initialize the starting page roller based on selected book
+bool ui_init_starting_page_roller(void);
+
 #endif // UI_MANAGER_H


### PR DESCRIPTION
## Summary
- add ui_init_starting_page_roller to populate the starting page roller
- hook up the roller initialization when switching from book selection

## Testing
- `./setup.sh`
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_6842494088e083238ef83e46b46af842